### PR TITLE
refactor: consolidate credential entry retrieval logic and improve validators

### DIFF
--- a/internal/provider/entry_credential_api_key_data_source.go
+++ b/internal/provider/entry_credential_api_key_data_source.go
@@ -2,14 +2,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -99,12 +96,7 @@ func (d *EntryCredentialApiKeyDataSource) Schema(ctx context.Context, req dataso
 }
 
 func (d *EntryCredentialApiKeyDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *EntryCredentialApiKeyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -135,48 +127,16 @@ func (d *EntryCredentialApiKeyDataSource) Read(ctx context.Context, req datasour
 		return
 	}
 
-	var entryCredentialApiKey dvls.Entry
-	var err error
-
-	if !data.Id.IsNull() && !data.Id.IsUnknown() {
-		if !data.Name.IsNull() || !data.Folder.IsNull() {
-			resp.Diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
-		}
-		entryCredentialApiKey, err = d.client.Entries.Credential.GetById(data.VaultId.ValueString(), data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("unable to read api key credential entry", err.Error())
-			return
-		}
-		if entryCredentialApiKey.Type != dvls.EntryCredentialType || entryCredentialApiKey.SubType != dvls.EntryCredentialSubTypeApiKey {
-			resp.Diagnostics.AddError("invalid entry type", "expected an api key credential entry.")
-			return
-		}
-	} else {
-		var folderPath *string
-		if !data.Folder.IsNull() && !data.Folder.IsUnknown() {
-			v := data.Folder.ValueString()
-			folderPath = &v
-		}
-		entryCredentialApiKey, err = d.client.Entries.Credential.GetByName(
-			data.VaultId.ValueString(),
-			data.Name.ValueString(),
-			dvls.EntryCredentialSubTypeApiKey,
-			dvls.GetByNameOptions{Path: folderPath},
-		)
-		if err != nil {
-			if errors.Is(err, dvls.ErrMultipleEntriesFound) {
-				resp.Diagnostics.AddError(
-					"multiple entries found",
-					fmt.Sprintf("more than one entry named %q found, use id to target the correct one", data.Name.ValueString()),
-				)
-				return
-			}
-			resp.Diagnostics.AddError("unable to read api key credential entry", err.Error())
-			return
-		}
+	entry, ok := getCredentialEntry(
+		d.client, &resp.Diagnostics,
+		data.Id, data.VaultId, data.Name, data.Folder,
+		dvls.EntryCredentialSubTypeApiKey, "api key",
+	)
+	if !ok {
+		return
 	}
 
-	setEntryCredentialApiKeyDataModel(entryCredentialApiKey, data)
+	setEntryCredentialApiKeyDataModel(entry, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/entry_credential_azure_service_principal_data_source.go
+++ b/internal/provider/entry_credential_azure_service_principal_data_source.go
@@ -2,14 +2,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -99,12 +96,7 @@ func (d *EntryCredentialAzureServicePrincipalDataSource) Schema(ctx context.Cont
 }
 
 func (d *EntryCredentialAzureServicePrincipalDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *EntryCredentialAzureServicePrincipalDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -135,48 +127,16 @@ func (d *EntryCredentialAzureServicePrincipalDataSource) Read(ctx context.Contex
 		return
 	}
 
-	var entryCredentialAzureServicePrincipal dvls.Entry
-	var err error
-
-	if !data.Id.IsNull() && !data.Id.IsUnknown() {
-		if !data.Name.IsNull() || !data.Folder.IsNull() {
-			resp.Diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
-		}
-		entryCredentialAzureServicePrincipal, err = d.client.Entries.Credential.GetById(data.VaultId.ValueString(), data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("unable to read azure service principal credential entry", err.Error())
-			return
-		}
-		if entryCredentialAzureServicePrincipal.Type != dvls.EntryCredentialType || entryCredentialAzureServicePrincipal.SubType != dvls.EntryCredentialSubTypeAzureServicePrincipal {
-			resp.Diagnostics.AddError("invalid entry type", "expected an azure service principal credential entry.")
-			return
-		}
-	} else {
-		var folderPath *string
-		if !data.Folder.IsNull() && !data.Folder.IsUnknown() {
-			v := data.Folder.ValueString()
-			folderPath = &v
-		}
-		entryCredentialAzureServicePrincipal, err = d.client.Entries.Credential.GetByName(
-			data.VaultId.ValueString(),
-			data.Name.ValueString(),
-			dvls.EntryCredentialSubTypeAzureServicePrincipal,
-			dvls.GetByNameOptions{Path: folderPath},
-		)
-		if err != nil {
-			if errors.Is(err, dvls.ErrMultipleEntriesFound) {
-				resp.Diagnostics.AddError(
-					"multiple entries found",
-					fmt.Sprintf("more than one entry named %q found, use id to target the correct one", data.Name.ValueString()),
-				)
-				return
-			}
-			resp.Diagnostics.AddError("unable to read azure service principal credential entry", err.Error())
-			return
-		}
+	entry, ok := getCredentialEntry(
+		d.client, &resp.Diagnostics,
+		data.Id, data.VaultId, data.Name, data.Folder,
+		dvls.EntryCredentialSubTypeAzureServicePrincipal, "azure service principal",
+	)
+	if !ok {
+		return
 	}
 
-	setEntryCredentialAzureServicePrincipalDataModel(entryCredentialAzureServicePrincipal, data)
+	setEntryCredentialAzureServicePrincipalDataModel(entry, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/entry_credential_connection_string_data_source.go
+++ b/internal/provider/entry_credential_connection_string_data_source.go
@@ -2,14 +2,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -89,12 +86,7 @@ func (d *EntryCredentialConnectionStringDataSource) Schema(ctx context.Context, 
 }
 
 func (d *EntryCredentialConnectionStringDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *EntryCredentialConnectionStringDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -125,48 +117,16 @@ func (d *EntryCredentialConnectionStringDataSource) Read(ctx context.Context, re
 		return
 	}
 
-	var entryCredentialConnectionString dvls.Entry
-	var err error
-
-	if !data.Id.IsNull() && !data.Id.IsUnknown() {
-		if !data.Name.IsNull() || !data.Folder.IsNull() {
-			resp.Diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
-		}
-		entryCredentialConnectionString, err = d.client.Entries.Credential.GetById(data.VaultId.ValueString(), data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("unable to read connection string credential entry", err.Error())
-			return
-		}
-		if entryCredentialConnectionString.Type != dvls.EntryCredentialType || entryCredentialConnectionString.SubType != dvls.EntryCredentialSubTypeConnectionString {
-			resp.Diagnostics.AddError("invalid entry type", "expected a connection string credential entry.")
-			return
-		}
-	} else {
-		var folderPath *string
-		if !data.Folder.IsNull() && !data.Folder.IsUnknown() {
-			v := data.Folder.ValueString()
-			folderPath = &v
-		}
-		entryCredentialConnectionString, err = d.client.Entries.Credential.GetByName(
-			data.VaultId.ValueString(),
-			data.Name.ValueString(),
-			dvls.EntryCredentialSubTypeConnectionString,
-			dvls.GetByNameOptions{Path: folderPath},
-		)
-		if err != nil {
-			if errors.Is(err, dvls.ErrMultipleEntriesFound) {
-				resp.Diagnostics.AddError(
-					"multiple entries found",
-					fmt.Sprintf("more than one entry named %q found, use id to target the correct one", data.Name.ValueString()),
-				)
-				return
-			}
-			resp.Diagnostics.AddError("unable to read connection string credential entry", err.Error())
-			return
-		}
+	entry, ok := getCredentialEntry(
+		d.client, &resp.Diagnostics,
+		data.Id, data.VaultId, data.Name, data.Folder,
+		dvls.EntryCredentialSubTypeConnectionString, "connection string",
+	)
+	if !ok {
+		return
 	}
 
-	setEntryCredentialConnectionStringDataModel(entryCredentialConnectionString, data)
+	setEntryCredentialConnectionStringDataModel(entry, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/entry_credential_lookup.go
+++ b/internal/provider/entry_credential_lookup.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Devolutions/go-dvls"
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var idOrNameConfigValidators = []datasource.ConfigValidator{
+	datasourcevalidator.AtLeastOneOf(
+		path.MatchRoot("id"),
+		path.MatchRoot("name"),
+	),
+}
+
+func getCredentialEntry(
+	client *dvls.Client,
+	diagnostics *diag.Diagnostics,
+	id, vaultId, name, folder types.String,
+	subType string,
+	entryTypeName string,
+) (dvls.Entry, bool) {
+	if !id.IsNull() && !id.IsUnknown() {
+		if !name.IsNull() || !folder.IsNull() {
+			diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
+		}
+
+		entry, err := client.Entries.Credential.GetById(vaultId.ValueString(), id.ValueString())
+		if err != nil {
+			diagnostics.AddError(fmt.Sprintf("unable to read %s credential entry", entryTypeName), err.Error())
+			return dvls.Entry{}, false
+		}
+
+		if entry.Type != dvls.EntryCredentialType || entry.SubType != subType {
+			diagnostics.AddError("invalid entry type", fmt.Sprintf("expected a %s credential entry.", entryTypeName))
+			return dvls.Entry{}, false
+		}
+
+		return entry, true
+	}
+
+	var folderPath *string
+	if !folder.IsNull() && !folder.IsUnknown() {
+		v := folder.ValueString()
+		folderPath = &v
+	}
+
+	entry, err := client.Entries.Credential.GetByName(
+		vaultId.ValueString(),
+		name.ValueString(),
+		subType,
+		dvls.GetByNameOptions{Path: folderPath},
+	)
+	if err != nil {
+		if errors.Is(err, dvls.ErrMultipleEntriesFound) {
+			diagnostics.AddError(
+				"multiple entries found",
+				fmt.Sprintf("more than one entry named %q found, use id to target the correct one", name.ValueString()),
+			)
+			return dvls.Entry{}, false
+		}
+
+		diagnostics.AddError(fmt.Sprintf("unable to read %s credential entry", entryTypeName), err.Error())
+		return dvls.Entry{}, false
+	}
+
+	return entry, true
+}

--- a/internal/provider/entry_credential_secret_data_source.go
+++ b/internal/provider/entry_credential_secret_data_source.go
@@ -2,14 +2,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -89,12 +86,7 @@ func (d *EntryCredentialSecretDataSource) Schema(ctx context.Context, req dataso
 }
 
 func (d *EntryCredentialSecretDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *EntryCredentialSecretDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -125,48 +117,16 @@ func (d *EntryCredentialSecretDataSource) Read(ctx context.Context, req datasour
 		return
 	}
 
-	var entryCredentialSecret dvls.Entry
-	var err error
-
-	if !data.Id.IsNull() && !data.Id.IsUnknown() {
-		if !data.Name.IsNull() || !data.Folder.IsNull() {
-			resp.Diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
-		}
-		entryCredentialSecret, err = d.client.Entries.Credential.GetById(data.VaultId.ValueString(), data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("unable to read secret credential entry", err.Error())
-			return
-		}
-		if entryCredentialSecret.Type != dvls.EntryCredentialType || entryCredentialSecret.SubType != dvls.EntryCredentialSubTypeAccessCode {
-			resp.Diagnostics.AddError("invalid entry type", "expected a secret credential entry.")
-			return
-		}
-	} else {
-		var folderPath *string
-		if !data.Folder.IsNull() && !data.Folder.IsUnknown() {
-			v := data.Folder.ValueString()
-			folderPath = &v
-		}
-		entryCredentialSecret, err = d.client.Entries.Credential.GetByName(
-			data.VaultId.ValueString(),
-			data.Name.ValueString(),
-			dvls.EntryCredentialSubTypeAccessCode,
-			dvls.GetByNameOptions{Path: folderPath},
-		)
-		if err != nil {
-			if errors.Is(err, dvls.ErrMultipleEntriesFound) {
-				resp.Diagnostics.AddError(
-					"multiple entries found",
-					fmt.Sprintf("more than one entry named %q found, use id to target the correct one", data.Name.ValueString()),
-				)
-				return
-			}
-			resp.Diagnostics.AddError("unable to read secret credential entry", err.Error())
-			return
-		}
+	entry, ok := getCredentialEntry(
+		d.client, &resp.Diagnostics,
+		data.Id, data.VaultId, data.Name, data.Folder,
+		dvls.EntryCredentialSubTypeAccessCode, "secret",
+	)
+	if !ok {
+		return
 	}
 
-	setEntryCredentialSecretDataModel(entryCredentialSecret, data)
+	setEntryCredentialSecretDataModel(entry, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/entry_credential_ssh_key_data_source.go
+++ b/internal/provider/entry_credential_ssh_key_data_source.go
@@ -2,14 +2,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -111,12 +108,7 @@ func (d *EntryCredentialSSHKeyDataSource) Schema(ctx context.Context, req dataso
 }
 
 func (d *EntryCredentialSSHKeyDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *EntryCredentialSSHKeyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -147,48 +139,16 @@ func (d *EntryCredentialSSHKeyDataSource) Read(ctx context.Context, req datasour
 		return
 	}
 
-	var entryCredentialSSHKey dvls.Entry
-	var err error
-
-	if !data.Id.IsNull() && !data.Id.IsUnknown() {
-		if !data.Name.IsNull() || !data.Folder.IsNull() {
-			resp.Diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
-		}
-		entryCredentialSSHKey, err = d.client.Entries.Credential.GetById(data.VaultId.ValueString(), data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("unable to read SSH key credential entry", err.Error())
-			return
-		}
-		if entryCredentialSSHKey.Type != dvls.EntryCredentialType || entryCredentialSSHKey.SubType != dvls.EntryCredentialSubTypePrivateKey {
-			resp.Diagnostics.AddError("invalid entry type", "expected a SSH key credential entry.")
-			return
-		}
-	} else {
-		var folderPath *string
-		if !data.Folder.IsNull() && !data.Folder.IsUnknown() {
-			v := data.Folder.ValueString()
-			folderPath = &v
-		}
-		entryCredentialSSHKey, err = d.client.Entries.Credential.GetByName(
-			data.VaultId.ValueString(),
-			data.Name.ValueString(),
-			dvls.EntryCredentialSubTypePrivateKey,
-			dvls.GetByNameOptions{Path: folderPath},
-		)
-		if err != nil {
-			if errors.Is(err, dvls.ErrMultipleEntriesFound) {
-				resp.Diagnostics.AddError(
-					"multiple entries found",
-					fmt.Sprintf("more than one entry named %q found, use id to target the correct one", data.Name.ValueString()),
-				)
-				return
-			}
-			resp.Diagnostics.AddError("unable to read SSH key credential entry", err.Error())
-			return
-		}
+	entry, ok := getCredentialEntry(
+		d.client, &resp.Diagnostics,
+		data.Id, data.VaultId, data.Name, data.Folder,
+		dvls.EntryCredentialSubTypePrivateKey, "SSH key",
+	)
+	if !ok {
+		return
 	}
 
-	setEntryCredentialSSHKeyDataModel(entryCredentialSSHKey, data)
+	setEntryCredentialSSHKeyDataModel(entry, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/entry_credential_username_password_data_source.go
+++ b/internal/provider/entry_credential_username_password_data_source.go
@@ -2,14 +2,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -99,12 +96,7 @@ func (d *EntryCredentialUsernamePasswordDataSource) Schema(ctx context.Context, 
 }
 
 func (d *EntryCredentialUsernamePasswordDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *EntryCredentialUsernamePasswordDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -135,48 +127,16 @@ func (d *EntryCredentialUsernamePasswordDataSource) Read(ctx context.Context, re
 		return
 	}
 
-	var entryCredentialUsernamePassword dvls.Entry
-	var err error
-
-	if !data.Id.IsNull() && !data.Id.IsUnknown() {
-		if !data.Name.IsNull() || !data.Folder.IsNull() {
-			resp.Diagnostics.AddWarning("id takes precedence", "When id is provided, name and folder are ignored.")
-		}
-		entryCredentialUsernamePassword, err = d.client.Entries.Credential.GetById(data.VaultId.ValueString(), data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("unable to read username password credential entry", err.Error())
-			return
-		}
-		if entryCredentialUsernamePassword.Type != dvls.EntryCredentialType || entryCredentialUsernamePassword.SubType != dvls.EntryCredentialSubTypeDefault {
-			resp.Diagnostics.AddError("invalid entry type", "expected an username password credential entry.")
-			return
-		}
-	} else {
-		var folderPath *string
-		if !data.Folder.IsNull() && !data.Folder.IsUnknown() {
-			v := data.Folder.ValueString()
-			folderPath = &v
-		}
-		entryCredentialUsernamePassword, err = d.client.Entries.Credential.GetByName(
-			data.VaultId.ValueString(),
-			data.Name.ValueString(),
-			dvls.EntryCredentialSubTypeDefault,
-			dvls.GetByNameOptions{Path: folderPath},
-		)
-		if err != nil {
-			if errors.Is(err, dvls.ErrMultipleEntriesFound) {
-				resp.Diagnostics.AddError(
-					"multiple entries found",
-					fmt.Sprintf("more than one entry named %q found, use id to target the correct one", data.Name.ValueString()),
-				)
-				return
-			}
-			resp.Diagnostics.AddError("unable to read username password credential entry", err.Error())
-			return
-		}
+	entry, ok := getCredentialEntry(
+		d.client, &resp.Diagnostics,
+		data.Id, data.VaultId, data.Name, data.Folder,
+		dvls.EntryCredentialSubTypeDefault, "username password",
+	)
+	if !ok {
+		return
 	}
 
-	setEntryCredentialUsernamePasswordDataModel(entryCredentialUsernamePassword, data)
+	setEntryCredentialUsernamePasswordDataModel(entry, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/entry_validators.go
+++ b/internal/provider/entry_validators.go
@@ -11,15 +11,15 @@ import (
 
 type entryIdValidator struct{}
 
-func (validator entryIdValidator) Description(_ context.Context) string {
+func (v entryIdValidator) Description(_ context.Context) string {
 	return "entry must be a valid UUID (ex.: 00000000-0000-0000-0000-000000000000)"
 }
 
-func (validator entryIdValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+func (v entryIdValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
 }
 
-func (d entryIdValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
+func (v entryIdValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/provider/vault.go
+++ b/internal/provider/vault.go
@@ -27,6 +27,12 @@ var vaultContentTypes map[dvls.VaultContentType]string = map[dvls.VaultContentTy
 	dvls.VaultContentTypeBusinessInformation: "business_information",
 }
 
+var (
+	vaultSecurityLevelValues = listMapValues(vaultSecurityLevels)
+	vaultVisibilityValues    = listMapValues(vaultVisibilities)
+	vaultContentTypeValues   = listMapValues(vaultContentTypes)
+)
+
 func newVaultFromResourceModel(data *VaultResourceModel) (dvls.Vault, error) {
 	securityLevel, err := lookupMapValue(vaultSecurityLevels, data.SecurityLevel.ValueString())
 	if err != nil {

--- a/internal/provider/vault_data_source.go
+++ b/internal/provider/vault_data_source.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 
 	"github.com/Devolutions/go-dvls"
-	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -78,12 +76,7 @@ func (d *VaultDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 }
 
 func (d *VaultDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
-	return []datasource.ConfigValidator{
-		datasourcevalidator.AtLeastOneOf(
-			path.MatchRoot("id"),
-			path.MatchRoot("name"),
-		),
-	}
+	return idOrNameConfigValidators
 }
 
 func (d *VaultDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/provider/vault_resource.go
+++ b/internal/provider/vault_resource.go
@@ -63,25 +63,25 @@ func (r *VaultResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:    true,
 			},
 			"visibility": schema.StringAttribute{
-				Description: fmt.Sprintf("Vault visibility. Must be one of the following: %s", listMapValues(vaultVisibilities)),
+				Description: fmt.Sprintf("Vault visibility. Must be one of the following: %s", vaultVisibilityValues),
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("default"),
-				Validators:  []validator.String{vaultVisibilityValidator{}},
+				Validators:  []validator.String{newVaultVisibilityValidator()},
 			},
 			"security_level": schema.StringAttribute{
-				Description: fmt.Sprintf("Vault security level. Must be one of the following: %s", listMapValues(vaultSecurityLevels)),
+				Description: fmt.Sprintf("Vault security level. Must be one of the following: %s", vaultSecurityLevelValues),
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("standard"),
-				Validators:  []validator.String{vaultSecurityLevelValidator{}},
+				Validators:  []validator.String{newVaultSecurityLevelValidator()},
 			},
 			"content_type": schema.StringAttribute{
-				Description: fmt.Sprintf("Vault content type. Must be one of: %s", listMapValues(vaultContentTypes)),
+				Description: fmt.Sprintf("Vault content type. Must be one of: %s", vaultContentTypeValues),
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("everything"),
-				Validators:  []validator.String{vaultContentTypeValidator{}},
+				Validators:  []validator.String{newVaultContentTypeValidator()},
 			},
 		},
 	}
@@ -158,14 +158,8 @@ func (r *VaultResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 func (r *VaultResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan *VaultResourceModel
-	var state *VaultResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -181,6 +175,8 @@ func (r *VaultResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("unable to update vault", err.Error())
 		return
 	}
+
+	setVaultResourceModel(vault, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/vault_validators.go
+++ b/internal/provider/vault_validators.go
@@ -4,21 +4,22 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Devolutions/go-dvls"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 type vaultIdValidator struct{}
 
-func (validator vaultIdValidator) Description(_ context.Context) string {
+func (v vaultIdValidator) Description(_ context.Context) string {
 	return "vault must be a valid UUID (ex.: 00000000-0000-0000-0000-000000000000)"
 }
 
-func (validator vaultIdValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+func (v vaultIdValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
 }
 
-func (d vaultIdValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
+func (v vaultIdValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}
@@ -32,80 +33,52 @@ func (d vaultIdValidator) ValidateString(_ context.Context, request validator.St
 	}
 }
 
-type vaultSecurityLevelValidator struct{}
-
-func (validator vaultSecurityLevelValidator) Description(_ context.Context) string {
-	values := listMapValues(vaultSecurityLevels)
-	return fmt.Sprintf("valid values are: %v", values)
+type vaultEnumValidator[K dvls.VaultSecurityLevel | dvls.VaultVisibility | dvls.VaultContentType] struct {
+	lookup    map[K]string
+	errTitle  string
+	errDetail string
 }
 
-func (validator vaultSecurityLevelValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+func (v vaultEnumValidator[K]) Description(_ context.Context) string {
+	return v.errDetail
 }
 
-func (d vaultSecurityLevelValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
+func (v vaultEnumValidator[K]) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v vaultEnumValidator[K]) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}
 
-	securityLevel := request.ConfigValue.ValueString()
-
-	_, err := lookupMapValue(vaultSecurityLevels, securityLevel)
+	_, err := lookupMapValue(v.lookup, request.ConfigValue.ValueString())
 	if err != nil {
-		values := listMapValues(vaultSecurityLevels)
-		response.Diagnostics.AddError("vault security level is invalid", fmt.Sprintf("valid values are: %s", values))
+		response.Diagnostics.AddError(v.errTitle, v.errDetail)
 		return
 	}
 }
 
-type vaultVisibilityValidator struct{}
-
-func (validator vaultVisibilityValidator) Description(_ context.Context) string {
-	values := listMapValues(vaultVisibilities)
-	return fmt.Sprintf("valid values are: %v", values)
-}
-
-func (validator vaultVisibilityValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
-}
-
-func (d vaultVisibilityValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
-	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
-		return
-	}
-
-	visibility := request.ConfigValue.ValueString()
-
-	_, err := lookupMapValue(vaultVisibilities, visibility)
-	if err != nil {
-		values := listMapValues(vaultVisibilities)
-		response.Diagnostics.AddError("vault visibility is invalid", fmt.Sprintf("valid values are: %s", values))
-		return
+func newVaultSecurityLevelValidator() vaultEnumValidator[dvls.VaultSecurityLevel] {
+	return vaultEnumValidator[dvls.VaultSecurityLevel]{
+		lookup:    vaultSecurityLevels,
+		errTitle:  "vault security level is invalid",
+		errDetail: fmt.Sprintf("valid values are: %s", vaultSecurityLevelValues),
 	}
 }
 
-type vaultContentTypeValidator struct{}
-
-func (validator vaultContentTypeValidator) Description(_ context.Context) string {
-	values := listMapValues(vaultContentTypes)
-	return fmt.Sprintf("valid values are: %v", values)
-}
-
-func (validator vaultContentTypeValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
-}
-
-func (d vaultContentTypeValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
-	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
-		return
+func newVaultVisibilityValidator() vaultEnumValidator[dvls.VaultVisibility] {
+	return vaultEnumValidator[dvls.VaultVisibility]{
+		lookup:    vaultVisibilities,
+		errTitle:  "vault visibility is invalid",
+		errDetail: fmt.Sprintf("valid values are: %s", vaultVisibilityValues),
 	}
+}
 
-	contentType := request.ConfigValue.ValueString()
-
-	_, err := lookupMapValue(vaultContentTypes, contentType)
-	if err != nil {
-		values := listMapValues(vaultContentTypes)
-		response.Diagnostics.AddError("vault content type is invalid", fmt.Sprintf("valid values are: %s", values))
-		return
+func newVaultContentTypeValidator() vaultEnumValidator[dvls.VaultContentType] {
+	return vaultEnumValidator[dvls.VaultContentType]{
+		lookup:    vaultContentTypes,
+		errTitle:  "vault content type is invalid",
+		errDetail: fmt.Sprintf("valid values are: %s", vaultContentTypeValues),
 	}
 }


### PR DESCRIPTION
Pour la PR https://github.com/Devolutions/terraform-provider-dvls/pull/25

Extracted shared credential entry lookup helper

New file: internal/provider/entry_credential_lookup.go
  - getCredentialEntry() — consolidates the ~35-line id-vs-name lookup block that was copy-pasted across all 6
  credential data sources into a single function
  - idOrNameConfigValidators — shared []datasource.ConfigValidator variable used by all 7 data sources (6 credentials + vault)

Simplified 6 credential data sources

Each Read() method went from ~50 lines to ~10 lines by calling getCredentialEntry(). Each ConfigValidators() now returns the shared variable. Removed unused imports (errors, datasourcevalidator, path).

Files: all entry_credential_*_data_source.go

Unified vault validators into a generic type

File: internal/provider/vault_validators.go
  - Replaced 3 near-identical structs (vaultSecurityLevelValidator, vaultVisibilityValidator, vaultContentTypeValidator) with a single vaultEnumValidator[K] generic type
  - Error detail string is pre-built at construction time (zero allocations in the validation hot path)
  - Standardized receiver naming to v (was inconsistent: validator for Description, d for ValidateString)

Pre-computed map value strings

File: internal/provider/vault.go
  - Added vaultSecurityLevelValues, vaultVisibilityValues, vaultContentTypeValues package-level vars
  - Eliminates repeated sort.Strings + strings.Join + fmt.Sprintf on every Schema() and validator Description() call

Fixed bugs in vault resource

File: internal/provider/vault_resource.go
  - Update(): added setVaultResourceModel(vault, plan) to use the API response instead of discarding it (was writing plan directly to state, causing drift if the server normalizes fields)
  - Update(): removed dead state variable that was loaded but never read

Standardized entry validator receiver naming

File: internal/provider/entry_validators.go
  - Changed inconsistent receivers (validator/d) to consistent v across all methods